### PR TITLE
Timestamp

### DIFF
--- a/noisemeter-device/data-packet.h
+++ b/noisemeter-device/data-packet.h
@@ -16,10 +16,6 @@ struct DataPacket
         average += (sample - average) / count;
     }
 
-    void setTimestamp() noexcept {
-        timestamp = Timestamp();
-    }
-
     int count = 0;
     float minimum = 999.f;
     float maximum = 0.f;

--- a/noisemeter-device/data-packet.h
+++ b/noisemeter-device/data-packet.h
@@ -1,0 +1,31 @@
+#ifndef DATAPACKET_H
+#define DATAPACKET_H
+
+#include "timestamp.h"
+
+#include <algorithm>
+
+struct DataPacket
+{
+    constexpr DataPacket() = default;
+
+    void add(float sample) noexcept {
+        count++;
+        minimum = std::min(minimum, sample);
+        maximum = std::max(maximum, sample);
+        average += (sample - average) / count;
+    }
+
+    void setTimestamp() noexcept {
+        timestamp = Timestamp();
+    }
+
+    int count = 0;
+    float minimum = 999.f;
+    float maximum = 0.f;
+    float average = 0.f;
+    Timestamp timestamp = Timestamp::invalidTimestamp();
+};
+
+#endif // DATAPACKET_H
+

--- a/noisemeter-device/noisemeter-device.ino
+++ b/noisemeter-device/noisemeter-device.ino
@@ -251,6 +251,7 @@ String createJSONPayload(String deviceId, float min, float max, float average) {
   doc["data"]["contents"][0]["Max"] = max;
   doc["data"]["contents"][0]["Mean"] = average;
   doc["data"]["contents"][0]["DeviceID"] = deviceId;  // TODO
+  doc["data"]["contents"][0]["Timestamp"] = String(Timestamp());
 
   // Serialize JSON document
   String json;

--- a/noisemeter-device/timestamp.h
+++ b/noisemeter-device/timestamp.h
@@ -22,6 +22,10 @@ public:
         return success ? tsbuf : "(error)";
     }
 
+    auto secondsBetween(Timestamp ts) const noexcept {
+        return std::difftime(ts.tm, tm);
+    }
+
     static void synchronize() {
         configTime(0, 0, "pool.ntp.org");
 

--- a/noisemeter-device/timestamp.h
+++ b/noisemeter-device/timestamp.h
@@ -1,0 +1,37 @@
+#ifndef TIMESTAMP_H
+#define TIMESTAMP_H
+
+#include <Arduino.h>
+#include <ctime>
+
+class Timestamp
+{
+public:
+    Timestamp(): tm(std::time(nullptr)) {}
+
+    bool valid() const noexcept {
+        return tm >= 8 * 3600 * 2;
+    }
+
+    operator String() const noexcept {
+        char tsbuf[32];
+        const auto timeinfo = std::gmtime(&tm);
+        const auto success = std::strftime(tsbuf, sizeof(tsbuf), "%c", timeinfo) > 0;
+
+        return success ? tsbuf : "(error)";
+    }
+
+    static void synchronize() {
+        configTime(0, 0, "pool.ntp.org");
+
+        do {
+            delay(1000);
+        } while (!Timestamp().valid());
+    }
+
+private:
+    std::time_t tm;
+};
+
+#endif // TIMESTAMP_H
+

--- a/noisemeter-device/timestamp.h
+++ b/noisemeter-device/timestamp.h
@@ -7,7 +7,8 @@
 class Timestamp
 {
 public:
-    Timestamp(): tm(std::time(nullptr)) {}
+    Timestamp(std::time_t tm_ = std::time(nullptr)):
+        tm(tm_) {}
 
     bool valid() const noexcept {
         return tm >= 8 * 3600 * 2;
@@ -27,6 +28,10 @@ public:
         do {
             delay(1000);
         } while (!Timestamp().valid());
+    }
+
+    static Timestamp invalidTimestamp() {
+        return Timestamp(0);
     }
 
 private:


### PR DESCRIPTION
Adds timestamps to uploaded measurement data to ensure the recorded time and date reflect when the recordings were taken, not when the server received them as it currently is. Also implements a list to hold onto the data of failed uploads so that measurements are not lost in case the WiFi temporarily disconnects.

These changes might want a bit more testing before they are merged.

Closes #9 and #10 .