### PR TITLE
Captive portal

### DIFF
--- a/noisemeter-device/access-point.h
+++ b/noisemeter-device/access-point.h
@@ -1,30 +1,32 @@
 #ifndef ACCESS_POINT_H
 #define ACCESS_POINT_H
 
+#include <DNSServer.h>
 #include <WebServer.h>
 
-class AccessPoint
+class AccessPoint : public RequestHandler
 {
     static constexpr auto SSID = "Noise meter";
     static constexpr auto Passkey = "noisemeter";
-    // IP address set in access-point.cpp
 
 public:
-    AccessPoint():
-        server(80), funcOnCredentialsReceived(nullptr) {}
+    // Begins hosting a WiFi access point with the credentials form as a
+    // captive portal.
+    AccessPoint(void (*func)(WebServer&)):
+        server(80),
+        onCredentialsReceived(func) {}
 
-    // Configure the WiFi radio to be an access point.
-    void begin();
-
-    // Enter main loop for executing the access point and web server.
+    // Enters an infinite loop to handle the access point and web server.
     [[noreturn]] void run();
 
-    // Set handler for reception of WiFi credentials.
-    void onCredentialsReceived(void (*func)(WebServer&));
+    // RequestHandler implementation for web server functionality.
+    bool canHandle(HTTPMethod, String) override;
+    bool handle(WebServer&, HTTPMethod, String) override;
 
 private:
+    DNSServer dns;
     WebServer server;
-    void (*funcOnCredentialsReceived)(WebServer&);
+    void (*onCredentialsReceived)(WebServer&);
 
     static const IPAddress IP;
     static const IPAddress Netmask;

--- a/noisemeter-device/noisemeter-device.ino
+++ b/noisemeter-device/noisemeter-device.ino
@@ -4,10 +4,9 @@
  * Open source dB meter code taken from Ivan Kostoski (https://github.com/ikostoski/esp32-i2s-slm)
  * 
  * TODO:
- *  - Use DNS to make a "captive portal" that brings users directly to the credentials form.
  *  - Encrypt the stored credentials (simple XOR with a long key?).
  *  - Add second step to Access Point flow - to gather users email, generate a UUID and upload them to the cloud. UUID to be saved in EEPROM
- *  - Add functionality to reset the device periodically (eg every 24 hours)
+ *  - Add functionality to reset the device periodically (eg every 24 hours)?
  */
 #include <ArduinoJson.h> // https://arduinojson.org/
 #include <ArduinoJson.hpp>

--- a/noisemeter-device/noisemeter-device.ino
+++ b/noisemeter-device/noisemeter-device.ino
@@ -160,16 +160,13 @@ void setup() {
 #ifndef UPLOAD_DISABLED
   // Run the access point if it is requested or if there are no valid credentials.
   bool resetPressed = !digitalRead(PIN_BUTTON);
-  if (resetPressed || !Creds.valid()) {
-    AccessPoint ap;
+  if (resetPressed || !Creds.valid() || Creds.get(Storage::Entry::SSID).isEmpty()) {
+    AccessPoint ap (saveNetworkCreds);
 
-    SERIAL.println("Erasing stored credentials...");
+    SERIAL.print("Erasing stored credentials...");
     Creds.clear();
-    SERIAL.print("Stored Credentials after erasing: ");
-    SERIAL.println(Creds);
+    SERIAL.println(" done.");
 
-    ap.onCredentialsReceived(saveNetworkCreds);
-    ap.begin();
     ap.run(); // does not return
   }
 


### PR DESCRIPTION
This builds off of the work done in the `dns` branch and the code from the [esp32-captive-portal-example](https://github.com/CivicTechTO/proj-noisemeter-device/blob/main/reference/esp32-captive-portal-example/esp32-captive-portal-example.cpp) to implement captive portal functionality in the latest code. I adjusted the code to follow Arduino's `RequestHandler` interface that I had our `AccessPoint` class inherit, so we could avoid including the additional Async libraries that the example code used.

The redirect on WiFi connection appears to be working: I've tested this on Windows/Firefox, Linux/Firefox, iOS/WebKit, and Android.